### PR TITLE
feat(db): add Eloquent models (batches, menu_days, dishes, yields, proteins, customers, orders)

### DIFF
--- a/app/Models/Batch.php
+++ b/app/Models/Batch.php
@@ -1,0 +1,8 @@
+<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class Batch extends Model{
+    protected $guarded=[]; 
+    public function menuDays(){return $this->hasMany(MenuDay::class);}
+    public function orders(){return $this->hasMany(Order::class);}
+}

--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -1,0 +1,7 @@
+<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class Customer extends Model{
+    protected $guarded=[];
+    public function orders(){return $this->hasMany(Order::class);}
+}

--- a/app/Models/Dish.php
+++ b/app/Models/Dish.php
@@ -1,0 +1,20 @@
+<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class Dish extends Model{
+    protected $guarded=[];
+    public function recipeYield(){return $this->hasOne(RecipeYield::class);}
+    public function proteinRequirements(){return $this->hasMany(DishProteinRequirement::class);}
+    public function isType(string $t):bool{return $this->type===$t;}
+    public function isLauk(){return $this->isType('LAUK');}
+    public function isSayur(){return $this->isType('SAYUR');}
+    public function isKarbo(){return $this->isType('KARBO');}
+    public function isBuah(){return $this->isType('BUAH');}
+    public function isPelengkap(){return $this->isType('PELENKAP');}
+    public function scopeType($q,$t){return $q->where('type',$t);}
+    public function scopeLauk($q){return $q->where('type','LAUK');}
+    public function scopeSayur($q){return $q->where('type','SAYUR');}
+    public function scopeKarbo($q){return $q->where('type','KARBO');}
+    public function scopeBuah($q){return $q->where('type','BUAH');}
+    public function scopePelengkap($q){return $q->where('type','PELENKAP');}
+}

--- a/app/Models/DishProteinRequirement.php
+++ b/app/Models/DishProteinRequirement.php
@@ -1,0 +1,8 @@
+<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class DishProteinRequirement extends Model{
+    protected $guarded=[];
+    public function dish(){return $this->belongsTo(Dish::class);}
+    public function proteinType(){return $this->belongsTo(ProteinType::class);}
+}

--- a/app/Models/MenuDay.php
+++ b/app/Models/MenuDay.php
@@ -1,0 +1,14 @@
+<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class MenuDay extends Model{
+    protected $guarded=[];
+    public function batch(){return $this->belongsTo(Batch::class);}
+    public function lauk1(){return $this->belongsTo(Dish::class,'lauk_1_id');}
+    public function lauk2(){return $this->belongsTo(Dish::class,'lauk_2_id');}
+    public function karbo(){return $this->belongsTo(Dish::class,'karbo_id');}
+    public function sayur(){return $this->belongsTo(Dish::class,'sayur_id');}
+    public function buah(){return $this->belongsTo(Dish::class,'buah_id');}
+    public function pelengkap(){return $this->belongsTo(Dish::class,'pelengkap_id');}
+    public function orderItems(){return $this->hasMany(OrderItem::class);}
+}

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -1,0 +1,9 @@
+<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class Order extends Model{
+    protected $guarded=[];
+    public function customer(){return $this->belongsTo(Customer::class);}
+    public function batch(){return $this->belongsTo(Batch::class);}
+    public function items(){return $this->hasMany(OrderItem::class);}
+}

--- a/app/Models/OrderItem.php
+++ b/app/Models/OrderItem.php
@@ -1,0 +1,10 @@
+<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class OrderItem extends Model{
+    protected $guarded=[];
+    protected $casts=['custom_requests'=>'array','swaps'=>'array','portion_multiplier'=>'float'];
+    public function order(){return $this->belongsTo(Order::class);}
+    public function menuDay(){return $this->belongsTo(MenuDay::class);}
+    public function override(){return $this->hasOne(OrderItemOverride::class);}
+}

--- a/app/Models/OrderItemOverride.php
+++ b/app/Models/OrderItemOverride.php
@@ -1,0 +1,7 @@
+<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class OrderItemOverride extends Model{
+    protected $guarded=[];
+    public function orderItem(){return $this->belongsTo(OrderItem::class);}
+}

--- a/app/Models/ProteinType.php
+++ b/app/Models/ProteinType.php
@@ -1,0 +1,7 @@
+<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class ProteinType extends Model{
+    protected $guarded=[];
+    public function dishProteinRequirements(){return $this->hasMany(DishProteinRequirement::class);}
+}

--- a/app/Models/RecipeYield.php
+++ b/app/Models/RecipeYield.php
@@ -1,0 +1,7 @@
+<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class RecipeYield extends Model{
+    protected $guarded=[];
+    public function dish(){return $this->belongsTo(Dish::class);}
+}


### PR DESCRIPTION
## Summary
- add batch, menu day, dish and associated yield and protein models
- add customer, order, and order item models with casting and override

## Testing
- `composer install` (fails: nette/schema requires php 7.1 - 8.3, current php 8.4.11)
- `find app/Models -maxdepth 1 -name '*.php' -exec php -l {} \;`


------
https://chatgpt.com/codex/tasks/task_e_689aab0ada908324ad3e42c5ab450d9c