### PR TITLE
feat(db): initial seeders with sample batch, menu, dishes, customer, orders

### DIFF
--- a/app/Models/Batch.php
+++ b/app/Models/Batch.php
@@ -1,0 +1,8 @@
+<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class Batch extends Model{
+    protected $guarded=[]; 
+    public function menuDays(){return $this->hasMany(MenuDay::class);}
+    public function orders(){return $this->hasMany(Order::class);}
+}

--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -1,0 +1,7 @@
+<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class Customer extends Model{
+    protected $guarded=[];
+    public function orders(){return $this->hasMany(Order::class);}
+}

--- a/app/Models/Dish.php
+++ b/app/Models/Dish.php
@@ -1,0 +1,20 @@
+<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class Dish extends Model{
+    protected $guarded=[];
+    public function recipeYield(){return $this->hasOne(RecipeYield::class);}
+    public function proteinRequirements(){return $this->hasMany(DishProteinRequirement::class);}
+    public function isType(string $t):bool{return $this->type===$t;}
+    public function isLauk(){return $this->isType('LAUK');}
+    public function isSayur(){return $this->isType('SAYUR');}
+    public function isKarbo(){return $this->isType('KARBO');}
+    public function isBuah(){return $this->isType('BUAH');}
+    public function isPelengkap(){return $this->isType('PELENKAP');}
+    public function scopeType($q,$t){return $q->where('type',$t);}
+    public function scopeLauk($q){return $q->where('type','LAUK');}
+    public function scopeSayur($q){return $q->where('type','SAYUR');}
+    public function scopeKarbo($q){return $q->where('type','KARBO');}
+    public function scopeBuah($q){return $q->where('type','BUAH');}
+    public function scopePelengkap($q){return $q->where('type','PELENKAP');}
+}

--- a/app/Models/DishProteinRequirement.php
+++ b/app/Models/DishProteinRequirement.php
@@ -1,0 +1,8 @@
+<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class DishProteinRequirement extends Model{
+    protected $guarded=[];
+    public function dish(){return $this->belongsTo(Dish::class);}
+    public function proteinType(){return $this->belongsTo(ProteinType::class);}
+}

--- a/app/Models/MenuDay.php
+++ b/app/Models/MenuDay.php
@@ -1,0 +1,14 @@
+<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class MenuDay extends Model{
+    protected $guarded=[];
+    public function batch(){return $this->belongsTo(Batch::class);}
+    public function lauk1(){return $this->belongsTo(Dish::class,'lauk_1_id');}
+    public function lauk2(){return $this->belongsTo(Dish::class,'lauk_2_id');}
+    public function karbo(){return $this->belongsTo(Dish::class,'karbo_id');}
+    public function sayur(){return $this->belongsTo(Dish::class,'sayur_id');}
+    public function buah(){return $this->belongsTo(Dish::class,'buah_id');}
+    public function pelengkap(){return $this->belongsTo(Dish::class,'pelengkap_id');}
+    public function orderItems(){return $this->hasMany(OrderItem::class);}
+}

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -1,0 +1,9 @@
+<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class Order extends Model{
+    protected $guarded=[];
+    public function customer(){return $this->belongsTo(Customer::class);}
+    public function batch(){return $this->belongsTo(Batch::class);}
+    public function items(){return $this->hasMany(OrderItem::class);}
+}

--- a/app/Models/OrderItem.php
+++ b/app/Models/OrderItem.php
@@ -1,0 +1,10 @@
+<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class OrderItem extends Model{
+    protected $guarded=[];
+    protected $casts=['custom_requests'=>'array','swaps'=>'array','portion_multiplier'=>'float'];
+    public function order(){return $this->belongsTo(Order::class);}
+    public function menuDay(){return $this->belongsTo(MenuDay::class);}
+    public function override(){return $this->hasOne(OrderItemOverride::class);}
+}

--- a/app/Models/OrderItemOverride.php
+++ b/app/Models/OrderItemOverride.php
@@ -1,0 +1,7 @@
+<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class OrderItemOverride extends Model{
+    protected $guarded=[];
+    public function orderItem(){return $this->belongsTo(OrderItem::class);}
+}

--- a/app/Models/ProteinType.php
+++ b/app/Models/ProteinType.php
@@ -1,0 +1,7 @@
+<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class ProteinType extends Model{
+    protected $guarded=[];
+    public function dishProteinRequirements(){return $this->hasMany(DishProteinRequirement::class);}
+}

--- a/app/Models/RecipeYield.php
+++ b/app/Models/RecipeYield.php
@@ -1,0 +1,7 @@
+<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class RecipeYield extends Model{
+    protected $guarded=[];
+    public function dish(){return $this->belongsTo(Dish::class);}
+}

--- a/database/migrations/2025_01_01_000001_create_dishes_table.php
+++ b/database/migrations/2025_01_01_000001_create_dishes_table.php
@@ -1,0 +1,12 @@
+<?php
+use Illuminate\Database\Migrations\Migration; use Illuminate\Database\Schema\Blueprint; use Illuminate\Support\Facades\Schema;
+return new class extends Migration{
+  public function up():void{
+    Schema::create('dishes',function(Blueprint $t){
+      $t->id(); $t->string('name');
+      $t->enum('type',['LAUK','SAYUR','KARBO','BUAH','PELENKAP'])->index();
+      $t->integer('default_yield_portion')->nullable();
+      $t->text('notes')->nullable(); $t->timestamps();
+    });
+  } public function down():void{Schema::dropIfExists('dishes');}
+};

--- a/database/migrations/2025_01_01_000002_create_batches_table.php
+++ b/database/migrations/2025_01_01_000002_create_batches_table.php
@@ -1,0 +1,9 @@
+<?php
+use Illuminate\Database\Migrations\Migration; use Illuminate\Database\Schema\Blueprint; use Illuminate\Support\Facades\Schema;
+return new class extends Migration{
+  public function up():void{
+    Schema::create('batches',function(Blueprint $t){
+      $t->id(); $t->string('name'); $t->date('start_date'); $t->date('end_date'); $t->text('notes')->nullable(); $t->timestamps();
+    });
+  } public function down():void{Schema::dropIfExists('batches');}
+};

--- a/database/migrations/2025_01_01_000003_create_recipe_yields_table.php
+++ b/database/migrations/2025_01_01_000003_create_recipe_yields_table.php
@@ -1,0 +1,10 @@
+<?php
+use Illuminate\Database\Migrations\Migration; use Illuminate\Database\Schema\Blueprint; use Illuminate\Support\Facades\Schema;
+return new class extends Migration{
+  public function up():void{
+    Schema::create('recipe_yields',function(Blueprint $t){
+      $t->id(); $t->foreignId('dish_id')->unique()->constrained()->cascadeOnDelete();
+      $t->integer('portions_per_recipe'); $t->timestamps();
+    });
+  } public function down():void{Schema::dropIfExists('recipe_yields');}
+};

--- a/database/migrations/2025_01_01_000004_create_protein_types_table.php
+++ b/database/migrations/2025_01_01_000004_create_protein_types_table.php
@@ -1,0 +1,7 @@
+<?php
+use Illuminate\Database\Migrations\Migration; use Illuminate\Database\Schema\Blueprint; use Illuminate\Support\Facades\Schema;
+return new class extends Migration{
+  public function up():void{
+    Schema::create('protein_types',function(Blueprint $t){ $t->id(); $t->string('name')->unique(); $t->timestamps(); });
+  } public function down():void{Schema::dropIfExists('protein_types');}
+};

--- a/database/migrations/2025_01_01_000005_create_dish_protein_requirements_table.php
+++ b/database/migrations/2025_01_01_000005_create_dish_protein_requirements_table.php
@@ -1,0 +1,13 @@
+<?php
+use Illuminate\Database\Migrations\Migration; use Illuminate\Database\Schema\Blueprint; use Illuminate\Support\Facades\Schema;
+return new class extends Migration{
+  public function up():void{
+    Schema::create('dish_protein_requirements',function(Blueprint $t){
+      $t->id(); 
+      $t->foreignId('dish_id')->constrained()->cascadeOnDelete();
+      $t->foreignId('protein_type_id')->constrained()->cascadeOnDelete();
+      $t->integer('grams_per_recipe'); $t->timestamps();
+      $t->unique(['dish_id','protein_type_id']);
+    });
+  } public function down():void{Schema::dropIfExists('dish_protein_requirements');}
+};

--- a/database/migrations/2025_01_01_000006_create_customers_table.php
+++ b/database/migrations/2025_01_01_000006_create_customers_table.php
@@ -1,0 +1,9 @@
+<?php
+use Illuminate\Database\Migrations\Migration; use Illuminate\Database\Schema\Blueprint; use Illuminate\Support\Facades\Schema;
+return new class extends Migration{
+  public function up():void{
+    Schema::create('customers',function(Blueprint $t){
+      $t->id(); $t->string('name'); $t->string('phone')->nullable(); $t->text('notes')->nullable(); $t->timestamps();
+    });
+  } public function down():void{Schema::dropIfExists('customers');}
+};

--- a/database/migrations/2025_01_01_000007_create_orders_table.php
+++ b/database/migrations/2025_01_01_000007_create_orders_table.php
@@ -1,0 +1,13 @@
+<?php
+use Illuminate\Database\Migrations\Migration; use Illuminate\Database\Schema\Blueprint; use Illuminate\Support\Facades\Schema;
+return new class extends Migration{
+  public function up():void{
+    Schema::create('orders',function(Blueprint $t){
+      $t->id();
+      $t->foreignId('customer_id')->constrained()->cascadeOnDelete();
+      $t->foreignId('batch_id')->constrained()->cascadeOnDelete();
+      $t->enum('type',['FULL_BATCH','PER_DAY'])->index();
+      $t->text('notes')->nullable(); $t->timestamps();
+    });
+  } public function down():void{Schema::dropIfExists('orders');}
+};

--- a/database/migrations/2025_01_01_000008_create_menu_days_table.php
+++ b/database/migrations/2025_01_01_000008_create_menu_days_table.php
@@ -1,0 +1,18 @@
+<?php
+use Illuminate\Database\Migrations\Migration; use Illuminate\Database\Schema\Blueprint; use Illuminate\Support\Facades\Schema;
+return new class extends Migration{
+  public function up():void{
+    Schema::create('menu_days',function(Blueprint $t){
+      $t->id();
+      $t->foreignId('batch_id')->constrained()->cascadeOnDelete();
+      $t->tinyInteger('day_of_week')->index(); // 1..5
+      $t->foreignId('lauk_1_id')->nullable()->constrained('dishes')->nullOnDelete();
+      $t->foreignId('lauk_2_id')->nullable()->constrained('dishes')->nullOnDelete();
+      $t->foreignId('karbo_id')->nullable()->constrained('dishes')->nullOnDelete();
+      $t->foreignId('sayur_id')->nullable()->constrained('dishes')->nullOnDelete();
+      $t->foreignId('buah_id')->nullable()->constrained('dishes')->nullOnDelete();
+      $t->foreignId('pelengkap_id')->nullable()->constrained('dishes')->nullOnDelete();
+      $t->timestamps();
+    });
+  } public function down():void{Schema::dropIfExists('menu_days');}
+};

--- a/database/migrations/2025_01_01_000009_create_order_items_table.php
+++ b/database/migrations/2025_01_01_000009_create_order_items_table.php
@@ -1,0 +1,16 @@
+<?php
+use Illuminate\Database\Migrations\Migration; use Illuminate\Database\Schema\Blueprint; use Illuminate\Support\Facades\Schema;
+return new class extends Migration{
+  public function up():void{
+    Schema::create('order_items',function(Blueprint $t){
+      $t->id();
+      $t->foreignId('order_id')->constrained()->cascadeOnDelete();
+      $t->foreignId('menu_day_id')->constrained()->cascadeOnDelete();
+      $t->decimal('portion_multiplier',5,2)->default(1.00);
+      $t->json('custom_requests')->nullable();
+      $t->json('swaps')->nullable();
+      $t->timestamps();
+      $t->unique(['order_id','menu_day_id']);
+    });
+  } public function down():void{Schema::dropIfExists('order_items');}
+};

--- a/database/migrations/2025_01_01_000010_create_order_item_overrides_table.php
+++ b/database/migrations/2025_01_01_000010_create_order_item_overrides_table.php
@@ -1,0 +1,17 @@
+<?php
+use Illuminate\Database\Migrations\Migration; use Illuminate\Database\Schema\Blueprint; use Illuminate\Support\Facades\Schema;
+return new class extends Migration{
+  public function up():void{
+    Schema::create('order_item_overrides',function(Blueprint $t){
+      $t->id();
+      $t->foreignId('order_item_id')->unique()->constrained()->cascadeOnDelete();
+      $t->foreignId('lauk_1_id')->nullable()->constrained('dishes')->nullOnDelete();
+      $t->foreignId('lauk_2_id')->nullable()->constrained('dishes')->nullOnDelete();
+      $t->foreignId('karbo_id')->nullable()->constrained('dishes')->nullOnDelete();
+      $t->foreignId('sayur_id')->nullable()->constrained('dishes')->nullOnDelete();
+      $t->foreignId('buah_id')->nullable()->constrained('dishes')->nullOnDelete();
+      $t->foreignId('pelengkap_id')->nullable()->constrained('dishes')->nullOnDelete();
+      $t->timestamps();
+    });
+  } public function down():void{Schema::dropIfExists('order_item_overrides');}
+};

--- a/database/seeders/BatchSeeder.php
+++ b/database/seeders/BatchSeeder.php
@@ -1,0 +1,32 @@
+<?php
+namespace Database\Seeders;
+use Illuminate\Database\Seeder;
+use App\Models\{Batch,MenuDay,Dish};
+use Carbon\Carbon;
+class BatchSeeder extends Seeder{
+    public function run(): void{
+        $batch = Batch::create([
+            'name'=>'Batch Minggu Ini',
+            'start_date'=>Carbon::now()->startOfWeek(),
+            'end_date'=>Carbon::now()->startOfWeek()->addDays(4),
+            'notes'=>'Contoh batch dengan menu lengkap',
+        ]);
+        $lauks = Dish::where('type','LAUK')->pluck('id')->toArray();
+        $karbos = Dish::where('type','KARBO')->pluck('id')->toArray();
+        $sayurs = Dish::where('type','SAYUR')->pluck('id')->toArray();
+        $buahs = Dish::where('type','BUAH')->pluck('id')->toArray();
+        $pelengkap = Dish::where('type','PELENKAP')->pluck('id')->toArray();
+        for($day=1;$day<=5;$day++){
+            MenuDay::create([
+                'batch_id'=>$batch->id,
+                'day_of_week'=>$day,
+                'lauk_1_id'=>$lauks[array_rand($lauks)],
+                'lauk_2_id'=>$lauks[array_rand($lauks)],
+                'karbo_id'=>$karbos[array_rand($karbos)],
+                'sayur_id'=>$sayurs[array_rand($sayurs)],
+                'buah_id'=>$buahs[array_rand($buahs)],
+                'pelengkap_id'=>$pelengkap[array_rand($pelengkap)],
+            ]);
+        }
+    }
+}

--- a/database/seeders/CustomerOrderSeeder.php
+++ b/database/seeders/CustomerOrderSeeder.php
@@ -1,0 +1,30 @@
+<?php
+namespace Database\Seeders;
+use Illuminate\Database\Seeder;
+use App\Models\{Customer,Order,MenuDay,OrderItem};
+class CustomerOrderSeeder extends Seeder{
+    public function run(): void{
+        $customer = Customer::create([
+            'name'=>'Hanung Prabowo',
+            'phone'=>'6288905356781',
+            'notes'=>'Contoh customer full batch',
+        ]);
+        $batchId = \App\Models\Batch::first()->id;
+        $order = Order::create([
+            'customer_id'=>$customer->id,
+            'batch_id'=>$batchId,
+            'type'=>'FULL_BATCH',
+            'notes'=>null,
+        ]);
+        $menuDays = MenuDay::where('batch_id',$batchId)->get();
+        foreach($menuDays as $day){
+            OrderItem::create([
+                'order_id'=>$order->id,
+                'menu_day_id'=>$day->id,
+                'portion_multiplier'=>1.0,
+                'custom_requests'=>null,
+                'swaps'=>null,
+            ]);
+        }
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -1,19 +1,12 @@
 <?php
-
 namespace Database\Seeders;
-
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
-
-class DatabaseSeeder extends Seeder
-{
-    /**
-     * Seed the application's database.
-     *
-     * @return void
-     */
-    public function run()
-    {
-        // \App\Models\User::factory(10)->create();
+class DatabaseSeeder extends Seeder{
+    public function run(): void{
+        $this->call([
+            DishSeeder::class,
+            BatchSeeder::class,
+            CustomerOrderSeeder::class,
+        ]);
     }
 }

--- a/database/seeders/DishSeeder.php
+++ b/database/seeders/DishSeeder.php
@@ -1,0 +1,22 @@
+<?php
+namespace Database\Seeders;
+use Illuminate\Database\Seeder;
+use App\Models\Dish;
+class DishSeeder extends Seeder{
+    public function run(): void{
+        $dishes = [
+            ['name'=>'Ayam Bakar Madu','type'=>'LAUK'],
+            ['name'=>'Ikan Salem Bumbu Kuning','type'=>'LAUK'],
+            ['name'=>'Nasi Putih','type'=>'KARBO'],
+            ['name'=>'Nasi Merah','type'=>'KARBO'],
+            ['name'=>'Tumis Pakcoy Wortel','type'=>'SAYUR'],
+            ['name'=>'Sayur Asem','type'=>'SAYUR'],
+            ['name'=>'Semangka','type'=>'BUAH'],
+            ['name'=>'Pisang','type'=>'BUAH'],
+            ['name'=>'Sambal Terasi','type'=>'PELENKAP'],
+        ];
+        foreach($dishes as $dish){
+            Dish::create($dish);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- seed sample dishes for multiple types
- seed a batch with randomized menu days
- seed a customer order spanning the batch's menu

## Testing
- `composer install` (fails: nette/schema requires php 7.1 - 8.3, current php 8.4.11)
- `find database/seeders -maxdepth 1 -name '*.php' -exec php -l {} \;`


------
https://chatgpt.com/codex/tasks/task_e_689aab0ada908324ad3e42c5ab450d9c